### PR TITLE
Changed status code from 404 to 200 if no expenses found.

### DIFF
--- a/routes/expenses.js
+++ b/routes/expenses.js
@@ -84,7 +84,7 @@ router.get('/week', [auth], async (req, res) => {
     });
 
     if (!expenses.length) {
-        return res.status(404).send([{
+        return res.status(200).send([{
             recorded_time: 0.0001,
         }]);
     }


### PR DESCRIPTION
Because, it is not actually an error, and if no expenses was found, it 
responses with a default recorded_time if no expenses created for the 
current week.