### PR TITLE
return current state of project after POST, instead of only ObjectID

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -117,15 +117,19 @@ router.post('/', [auth, admin], async (req, res) => {
     project = await project.save();
     const projectID = project._id;
 
-    positions.forEach(async (pos) => {
-        let position = new Position(pos);
-        position = await position.save();
-        const positionID = position._id;
+    async function pushPositions(arr) { /* eslint-disable */
+        for (const pos of arr) {
+            let position = new Position(pos);
+            position = await position.save();
+            const positionID = position._id;
 
-        project = await Project.findByIdAndUpdate(projectID, { $push: { positions: positionID } });
-    });
-
-    return res.send(`Project with id ${project._id} created.`);
+            await Project.findByIdAndUpdate(projectID, { $push: { positions: positionID } });
+        }
+        project = await Project.findById(projectID);
+        return project;
+    }
+    project = await pushPositions(positions);
+    return res.send(project);
 });
 
 router.put('/:id', [auth, admin, oIdValidator], async (req, res) => {


### PR DESCRIPTION
made use of async await and for..of loop.

Before, the response after POST /api/projects/ did just send "Project with id XYZ created."
Now, the current state is sent including the position ObjectIDs inside the project.